### PR TITLE
add dev graph

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_MODE=dev

--- a/src/pages/GraphCanvas.jsx
+++ b/src/pages/GraphCanvas.jsx
@@ -3,6 +3,7 @@ import Node from "./../components/Node";
 import { BFS } from "../algorithms/BFS";
 import { useLocation } from "react-router-dom";
 import "./../styles/pages/GraphCanvas.css";
+import { getTestGraph } from "../utils/testGraph";
 
 const AlgorithmTrace = ({ currentStep, startNode, endNode, path, isCompleted, functionType, result }) => {
   if (!currentStep) return null;
@@ -173,7 +174,30 @@ const GraphCanvas = () => {
   const [endNodeId, setEndNodeId] = useState(null);
   const [path, setPath] = useState([]);
   const [isRunning, setIsRunning] = useState(false);
+  const [isDev, setIsDev] = useState(false);
+  const [visualFunction, setVisualFunction] = useState("traversal");
 
+  useEffect(() => {
+    // Check if we're in dev mode
+    const mode = import.meta.env.VITE_MODE || 'production';
+    setIsDev(mode === 'dev');
+    
+    // Load test graph if in dev mode
+    if (mode === 'dev') {
+      handleLoadTestGraph();
+    }
+  }, []);
+
+  // Handler to load test graph
+  const handleLoadTestGraph = () => {
+    const { nodes: testNodes, edges: testEdges } = getTestGraph();
+    setNodes(testNodes);
+    setEdges(testEdges);
+    // Set nextId to be one more than the highest node id
+    const maxId = Math.max(...testNodes.map(node => node.id));
+    setNextId(maxId + 1);
+  };
+  
   const handleAddNode = () => {
     const x = 100 + Math.random() * 400;
     const y = 100 + Math.random() * 400;
@@ -413,8 +437,69 @@ const GraphCanvas = () => {
 
   const getNodeById = (id) => nodes.find((n) => n.id === id);
 
+  const handleClearGraph = () => {
+    setNodes([]);
+    setEdges([]);
+    setNextId(1);
+    setSteps([]);
+    setCurrentStepIdx(0);
+    setSelectedNodeId(undefined);
+    if (typeof setSecondNodeId === 'function') {
+      setSecondNodeId(null);
+    }
+    if (typeof setPathResults === 'function') {
+      setPathResults(null);
+    }
+    if (typeof setShowComponents === 'function') {
+      setShowComponents(false);
+    }
+    if (typeof setComponentSteps === 'function') {
+      setComponentSteps([]);
+    }
+  };
+  
   return (
     <div>
+      {isDev && (
+        <div style={{ 
+          backgroundColor: '#f8f9fa', 
+          padding: '10px', 
+          borderRadius: '8px',
+          marginBottom: '10px',
+          border: '1px solid #ddd'
+        }}>
+          <div style={{ fontWeight: 'bold', marginBottom: '8px' }}>Test Controls</div>
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <button 
+              onClick={handleLoadTestGraph}
+              style={{ 
+                backgroundColor: '#28a745', 
+                color: 'white', 
+                border: 'none', 
+                padding: '5px 10px', 
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              Load Test Graph
+            </button>
+            <button 
+              onClick={handleClearGraph}
+              style={{ 
+                backgroundColor: '#dc3545', 
+                color: 'white', 
+                border: 'none', 
+                padding: '5px 10px', 
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              Delete Graph
+            </button>
+          </div>
+        </div>
+      )}
+      
       {/* Graph creation controls */}
       <div
         style={{

--- a/src/utils/testGraph.js
+++ b/src/utils/testGraph.js
@@ -1,0 +1,55 @@
+// Simple test graph data
+export const getTestGraph = () => {
+  return {
+    nodes: [
+      { id: 1, x: 150, y: 100 },
+      { id: 2, x: 270, y: 80 },
+      { id: 3, x: 390, y: 100 },
+      { id: 4, x: 180, y: 220 },
+      { id: 5, x: 300, y: 220 },
+      { id: 6, x: 420, y: 220 },
+      { id: 7, x: 240, y: 340 },
+      { id: 8, x: 360, y: 340 },
+      { id: 9, x: 620, y: 100 },
+      { id: 10, x: 550, y: 200 },
+      { id: 11, x: 690, y: 200 },
+      { id: 12, x: 620, y: 340 },
+      { id: 13, x: 100, y: 450 },
+      { id: 14, x: 200, y: 450 },
+    ],
+    edges: [
+      { a: 1, b: 2, weight: 4 },
+      { a: 1, b: 4, weight: 3 },
+      { a: 2, b: 3, weight: 2 },
+      { a: 2, b: 5, weight: 5 },
+      { a: 3, b: 6, weight: 1 },
+      { a: 4, b: 5, weight: 2 },
+      { a: 4, b: 7, weight: 6 },
+      { a: 5, b: 6, weight: 4 },
+      { a: 5, b: 8, weight: 3 },
+      { a: 6, b: 8, weight: 2 },
+      { a: 7, b: 8, weight: 4 },
+      { a: 9, b: 10, weight: 2 },
+      { a: 10, b: 11, weight: 3 },
+      { a: 11, b: 9, weight: 4 },
+      { a: 13, b: 14, weight: 5 },
+    ]
+  };
+};
+
+/**
+ * Returns an array of the connected components in the test graph
+ * Useful for visualizing and testing component detection algorithms
+ */
+export function getTestGraphComponents() {
+  return [
+    // Component IDs grouped by connected component
+    [1, 2, 3, 4, 5, 6, 7, 8], // Main component
+    [9, 10, 11],              // Triangle
+    [12],                     // Isolated node
+    [13, 14]                  // Line
+  ];
+}
+
+// Add default export for compatibility
+export default { getTestGraph, getTestGraphComponents };


### PR DESCRIPTION
## Summary by Sourcery

Add a development-only test graph loader and controls to the GraphCanvas component using a new testGraph utility module to speed up manual testing and debugging.

New Features:
- Introduce a src/utils/testGraph module exporting sample graph data and connected component definitions
- Detect VITE_MODE 'dev' in GraphCanvas and auto-load the sample graph when in dev mode
- Add a Test Controls panel with 'Load Test Graph' and 'Delete Graph' buttons, plus corresponding handlers to populate or clear the graph