### PR TITLE
add directed graph support

### DIFF
--- a/src/styles/pages/GraphCanvas.css
+++ b/src/styles/pages/GraphCanvas.css
@@ -595,3 +595,39 @@
   font-weight: bold;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
+.load-directed-btn {
+  background-color: #6366f1; /* Indigo */
+  color: white;
+}
+
+/* Directed graph arrows - Simple clean design */
+.edge-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 10px solid #64748b;
+  z-index: 2;
+}
+
+.edge-arrow.path-edge {
+  border-left-color: #22c55e;
+}
+
+/* Directed graph indicators - Better positioning */
+.edge-indicator {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background-color: #64748b;
+  border-radius: 50%;
+  z-index: 2;
+  box-shadow: 0 0 3px rgba(0,0,0,0.3);
+}
+
+.edge-indicator.path-edge {
+  background-color: #22c55e;
+  box-shadow: 0 0 4px rgba(34, 197, 94, 0.8);
+}

--- a/src/utils/testGraph.js
+++ b/src/utils/testGraph.js
@@ -51,5 +51,46 @@ export function getTestGraphComponents() {
   ];
 }
 
+/**
+ * Returns a directed test graph
+ * Useful for testing directed graph algorithms
+ */
+export const getDirectedTestGraph = () => {
+  return {
+    nodes: [
+      { id: 1, x: 150, y: 100 },
+      { id: 2, x: 250, y: 100 },
+      { id: 3, x: 350, y: 100 },
+      { id: 4, x: 150, y: 200 },
+      { id: 5, x: 250, y: 200 },
+      { id: 6, x: 350, y: 200 },
+      { id: 7, x: 150, y: 300 },
+      { id: 8, x: 250, y: 300 },
+      { id: 9, x: 350, y: 300 },
+      { id: 10, x: 500, y: 150 },
+      { id: 11, x: 600, y: 150 },
+      { id: 12, x: 500, y: 250 },
+    ],
+    edges: [
+      { a: 1, b: 2, weight: 3 },
+      { a: 2, b: 3, weight: 2 },
+      { a: 1, b: 4, weight: 4 },
+      { a: 2, b: 5, weight: 1 },
+      { a: 3, b: 6, weight: 5 },
+      { a: 4, b: 5, weight: 2 },
+      { a: 5, b: 6, weight: 3 },
+      { a: 4, b: 7, weight: 4 },
+      { a: 5, b: 8, weight: 5 },
+      { a: 6, b: 9, weight: 2 },
+      { a: 7, b: 8, weight: 3 },
+      { a: 8, b: 9, weight: 4 },
+      // Cycle
+      { a: 10, b: 11, weight: 2 },
+      { a: 11, b: 12, weight: 3 },
+      { a: 12, b: 10, weight: 1 },
+    ]
+  };
+};
+
 // Add default export for compatibility
-export default { getTestGraph, getTestGraphComponents };
+export default { getTestGraph, getTestGraphComponents, getDirectedTestGraph };


### PR DESCRIPTION
## Summary by Sourcery

Add end-to-end directed graph support by extending the test graph utilities, providing a dedicated load control, and rendering edge direction and weight with updated positioning and styles

New Features:
- Allow loading a directed test graph via a new “Load Directed Graph” button in the GraphCanvas component
- Introduce a getDirectedTestGraph utility and export it for generating directed test data
- Render directed edges with arrow indicators and maintain the correct directed graph mode state

Enhancements:
- Rename the original test graph button to “Load Undirected Graph”
- Position edge arrows and weight labels more precisely on the canvas
- Add CSS styling for directed graph controls, arrow indicators, and edge markers